### PR TITLE
Fix spacing (sentence-end-space)

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -3,13 +3,13 @@
 \usepackage[proceedings,crop]{llncsconf}
  
 \conference{International Conference on \LaTeX-Hacks}
-\llncs{Anonymous et al. (eds). \emph{Proceedings of the International 
+\llncs{Anonymous et al.\ (eds).\ \emph{Proceedings of the International
        Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
 \title{A Simple Example of the \texttt{llncsconf} Package for \LaTeX}
 
 
 \author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
-\institute{Some Departement, Somewhere}
+\institute{Some Department, Somewhere}
 
 \begin{document}
 


### PR DESCRIPTION
LLNCS defines `\frenchspacing`, which treats dots at end of sentences different than dots in the middle of a sentence.

Long discussion about that thing:
- https://english.stackexchange.com/a/2602/66058
- https://abovethelaw.com/2017/03/in-defense-of-space-the-extra-one-after-a-period/

To prevent a too long space at abbreviations one has to use `\ `. In case of capital letters, this is not necessary, because that is not treated as end-of-sentence. That means "Achim D. Brucker" does not need to be modified. - I nevertheless fixed a typo.
