### PR TITLE
Update notice to v3 of Springer's requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ to use the style. The package supports the following options:
   * `intended`: adds a *submitted to ... please to no distribute* note
     to the first page.
   * `llncs`: typesets a copy of Springer's copyright note. This should
-    satisfy Springer's requirements for self-archiving. 
+    satisfy Springer's requirements for self-archiving.
+    You need to supply the DOI using `\llncsdoi{DOI}`.
   * `proceedings`: typesets a note in which proceedings the paper was
-    published (similar to `llncs` without Springer's copyright note).
+    published (similar to `llncs` without Springer's availability note).
 
 Moreover, the package requires two commands to be executed:
 * `\conference{name of the conference}` which takes one argument,
@@ -35,7 +36,18 @@ Moreover, the package requires two commands to be executed:
 * `\llncs{book editors and title}{start page}` which takes two
   arguments: first the information about the book (e.g., editors,
   title) and, second, the start page of the chapter (contribution).
-  
+* `\llncsdoi{DOI}` which takes one argument,
+  i.e., the DOI of the final publication available at Springer's web site.
+
+## Self-Archiving
+Sprinter states in his [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3):
+
+> Author may only post his/her own version, provided acknowledgment is given to the original source of publication and a link is inserted to the published article on Springer’s website.
+> The link must be provided by inserting the DOI number of the article in the following sentence:
+> "The final publication is available at Springer via `http://dx.doi.org/[insert DOI]`".
+The DOI (Digital Object Identifier) can be found at the bottom of the first page of the published paper.
+
+This package uses `https://doi.org` as `http://dx.doi.org` [is deprecated](https://www.doi.org/factsheets/DOIIdentifierSpecs.html).
 
 ## License
 This project is dual-licensed under a 2-clause BSD-style license and/or 

--- a/example-llncs.tex
+++ b/example-llncs.tex
@@ -1,0 +1,31 @@
+\documentclass[final, runningheads, USenglish, pdftex]{llncs}
+\usepackage{lipsum}
+\usepackage[llncs,crop]{llncsconf}
+
+\conference{International Conference on \LaTeX-Hacks}
+\llncs{Anonymous et al. (eds). \emph{Proceedings of the International
+       Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
+\llncsdoi{10.1038/nphys1170}
+\title{A Simple Example of the \texttt{llncsconf} Package for \LaTeX}
+
+
+\author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
+\institute{Some Departement, Somewhere}
+
+\begin{document}
+
+\maketitle{}
+\begin{abstract}
+\lipsum[1-2]
+\end{abstract}
+
+\section{Introduction}
+\lipsum[1-4]
+
+\section{Contribution}
+\lipsum[5-10]
+
+\section{Conclusion}
+\lipsum[10-12]
+% \label{LastPage}
+\end{document}

--- a/llncsconf.sty
+++ b/llncsconf.sty
@@ -34,6 +34,8 @@
 \AtEndDocument{\label{LastPage}}
 \def\conference#1{\gdef\@conference{#1}}
 \def\llncs#1#2{\gdef\@llncs{#1}\ifthenelse{\boolean{llncs} \OR \boolean{proceedings}}{\setcounter{page}{#2}}{}}
+\gdef\@llncsdoi{UNKNOWN}
+\def\llncsdoi#1{\gdef\@llncsdoi{#1}{}}
 
 % <crop>
 \ifthenelse{\boolean{crop}}{%
@@ -96,7 +98,7 @@
      \vbox to\z@{\parindent=\z@\vss
      \@llncs
      \unskip, pp. \thepage--\pageref{LastPage}, \number\year.\\
-     \copyright\ Springer-Verlag Berlin Heidelberg \number\year
+     The final publication is available at Springer via \url{https://doi.org/\@llncsdoi}.
      }}\let\@evenfoot\@oddfoot}
 
 \def\ps@proceedings{\let\@mkboth\@gobbletwo\let\@oddhead\@empty\let\@evenhead\@empty


### PR DESCRIPTION
Srpinger is very explicit in his [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3) about self-archiving:

> Author may only post his/her own version, provided acknowledgment is given to the original source of publication and a link is inserted to the published article on Springer’s website.
> The link must be provided by inserting the DOI number of the article in the following sentence:
> "The final publication is available at Springer via `http://dx.doi.org/[insert DOI]`".
The DOI (Digital Object Identifier) can be found at the bottom of the first page of the published paper.

This PR implements that requirement. Note that "(c) by Springer-Verlag Berlin Heidelberg" is removed as Springer does guarantee quality of any LaTeX document typeset outside of Springer.

- Add `\llncsdoi`
- Add `example-llncs.tex`
- Refine README.md

The decision to add a separate `\llncsdoi` command and not adding a third paramter to `\llncs` was taken, because the `proceedings` option also uses the contents defined by `\llncs`. So, this is backwards compatible.