### PR TITLE
\clearheaderinfo does nothing even in the case of non-llncs

### DIFF
--- a/llncsconf.sty
+++ b/llncsconf.sty
@@ -152,7 +152,7 @@
 }{}
 
 \setcounter{tocdepth}{2}
-\renewcommand{\clearheadinfo}{}
+\let\clearheadinfo\relax
 \hypersetup{%
   draft         = false,
   bookmarksopen = true,


### PR DESCRIPTION
I am successfully using this package together with the [IEEE class](http://latextemplates.github.io/IEEE/). Since IEEEtran does not define `\clearheaderinfo`, I had to "dirtly" disable the command.