### PR TITLE
Add accepted option and improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,23 @@ In a LaTeX file that uses Springer's `llncs` class, just add
 to use the style. The package supports the following options:
   * `crop`: crops the page (PDF) to the page size (152x235mm) used by
     the LNCS proceedings books (and the official PDFs offered by
-    Springer),
+    Springer). Please ensure that you *do not* have the option
+    `a4paper` activated. Otherwise, cropping produces wrong results.
   * `rcsinfo`: adds RCS revision information to the first page of
-    the document,
+    the document.
   * `svninfo`: adds subversion/svn revision information to the
-    first page of the document,
-  * `submitted`: adds a *submitted to ... please to no distribute* note
-    to the first page.
-  * `intended`: adds a *submitted to ... please to no distribute* note
-    to the first page.
+    first page of the document.
   * `llncs`: typesets a copy of Springer's copyright note. This should
     satisfy Springer's requirements for self-archiving. 
   * `proceedings`: typesets a note in which proceedings the paper was
     published (similar to `llncs` without Springer's copyright note).
+  * `accepted`: adds a *accepted for publication at ...* note
+    to the first page. This is useful for the phase where the camera
+    ready version is prepared, but the publisher did not yet publish it.
+  * `submitted`: adds a *submitted to ... please to no distribute* note
+    to the first page.
+  * `intended`: adds a *submitted to ... please to no distribute* note
+    to the first page.
 
 Moreover, the package requires two commands to be executed:
 * `\conference{name of the conference}` which takes one argument,
@@ -35,6 +39,7 @@ Moreover, the package requires two commands to be executed:
 * `\llncs{book editors and title}{start page}` which takes two
   arguments: first the information about the book (e.g., editors,
   title) and, second, the start page of the chapter (contribution).
+  This is used in the case of `llncs` and `proceedings`.
   
 
 ## License

--- a/llncsconf.sty
+++ b/llncsconf.sty
@@ -15,6 +15,7 @@
 %
 \newboolean{rcsinfo}
 \newboolean{svninfo}
+\newboolean{accepted}
 \newboolean{submitted}
 \newboolean{intended}
 \newboolean{llncs}
@@ -24,6 +25,7 @@
 \DeclareOption{crop}{\setboolean{crop}{true}}
 \DeclareOption{rcsinfo}{\setboolean{rcsinfo}{true}}
 \DeclareOption{svninfo}{\setboolean{svninfo}{true}}
+\DeclareOption{accepted}{\setboolean{accepted}{true}}
 \DeclareOption{submitted}{\setboolean{submitted}{true}}
 \DeclareOption{intended}{\setboolean{intended}{true}}
 \DeclareOption{llncs}{\setboolean{llncs}{true}}
@@ -66,6 +68,12 @@
      \quad Time: \rcsInfoTime \quad File: \rcsInfoFile\\}}
      }\let\@evenfoot\@oddfoot}
 %
+\def\ps@acceptedfirst{\let\@mkboth\@gobbletwo\let\@oddhead\@empty\let\@evenhead\@empty
+     \def\@oddfoot{\reset@font\scriptsize
+          \vbox to\z@{\parindent=\z@\vss
+          Accepted for publication at \@conference.
+               }}\let\@evenfoot\@oddfoot}
+%
 \def\ps@submitted{\let\@mkboth\@gobbletwo
      \def\@oddfoot{\reset@font\scriptsize
           \vbox to\z@{\parindent=\z@\vss
@@ -78,7 +86,6 @@
           Submitted to \@conference, please do \emph{not} distribute.\\
                \copyright\ \number\year, \@author
                }}\let\@evenfoot\@oddfoot}
-%
 %
 \def\ps@intended{\let\@mkboth\@gobbletwo
      \def\@oddfoot{\reset@font\scriptsize
@@ -128,12 +135,20 @@
 %\def\maketitle{\old@mkttl\thispagestyle{svninfofirst}}%
 }{}
 % </svninfo>
-% <submitted>
+% <accepted>
+\ifthenelse{\boolean{accepted}}{%
+\let\old@mkttl=\maketitle%
+\def\maketitle{\old@mkttl\thispagestyle{acceptedfirst}}%
+}{}
+% </accepted>
+% <intended>
 \ifthenelse{\boolean{intended}}{%
 % \pagestyle{intended}%
 \let\old@mkttl=\maketitle%
 \def\maketitle{\old@mkttl\thispagestyle{intendedfirst}}%
 }{}
+% </intended>
+% <submitted>
 \ifthenelse{\boolean{submitted}}{%
 \pagestyle{submitted}%
 \let\old@mkttl=\maketitle%


### PR DESCRIPTION
For the phase between submitting the camera ready and final publishing a text like "Accepted for publication at" is needed. This is added here.

I did not add a copyright text including `\@author`, because then my document did not compile any more. Maybe, that macro has difficulties with multiple institutes etc. However, I think, a copyright statement is not necessary.