### PR TITLE
Fix space after "pp."

### DIFF
--- a/llncsconf.sty
+++ b/llncsconf.sty
@@ -104,7 +104,7 @@
      \def\@oddfoot{\reset@font\scriptsize
      \vbox to\z@{\parindent=\z@\vss
      \@llncs
-     \unskip, pp. \thepage--\pageref{LastPage}, \number\year.\\
+     \unskip, pp.~\thepage--\pageref{LastPage}, \number\year.\\
      The final publication is available at Springer via \url{https://doi.org/\@llncsdoi}.
      }}\let\@evenfoot\@oddfoot}
 
@@ -112,7 +112,7 @@
      \def\@oddfoot{\reset@font\scriptsize
      \vbox to\z@{\parindent=\z@\vss
      \@llncs
-     \unskip, pp. \thepage--\pageref{LastPage}, \number\year.
+     \unskip, pp.~\thepage--\pageref{LastPage}, \number\year.
      }}\let\@evenfoot\@oddfoot}
 
 % <rcsinfo>


### PR DESCRIPTION
Similar to https://github.com/adbrucker/llncsconf/pull/2, but I overlooked `pp. \thepage` at that PR.