### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -6,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## 1.0.0 - 2018-02-20
 ### Added
+
+- Added support for letter format
+
+## 1.0.0 - 2018-02-20
+
+### Added
+
 - Initial version uploaded to CTAN.
 
 [Unreleased]: https://git.logicalhacking.com/adbrucker/llncsconf/compare/v1.0.0...HEAD


### PR DESCRIPTION
While inspecting https://github.com/adbrucker/llncsconf/compare/v1.0.0...master I saw that the changes include a detection of a4paper. I added this to the CHANGELOG.md

Moreover, I applied to rules of [markdownlint](https://github.com/DavidAnson/markdownlint).