### PR TITLE
Add initial GitHub workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,60 @@
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: check
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: localhost:5000/name/app:latest
+          file: test/Dockerfile
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+      - run: |
+          mkdir /tmp/out
+          mkdir /tmp/res
+
+          # use latest development verison for testing
+          cp llncsconf.sty test
+      - name: example-intended
+        run: docker run -v $(pwd)/test:/work/src -v /tmp/out:/work/out localhost:5000/name/app:latest work "pdflatex example-intended.tex"
+      - run: mv /tmp/out/*.pdf /tmp/res
+      - name: example-submitted
+        run: docker run -v $(pwd)/test:/work/src -v /tmp/out:/work/out localhost:5000/name/app:latest work "pdflatex example-submitted.tex"
+      - run: mv /tmp/out/*.pdf /tmp/res
+      - name: example-accepted
+        run: docker run -v $(pwd)/test:/work/src -v /tmp/out:/work/out localhost:5000/name/app:latest work "pdflatex example-accepted.tex"
+      - run: mv /tmp/out/*.pdf /tmp/res
+      - name: example-proceedings
+        run: docker run -v $(pwd)/test:/work/src -v /tmp/out:/work/out localhost:5000/name/app:latest work "pdflatex example-proceedings.tex"
+      - run: mv /tmp/out/*.pdf /tmp/res
+      - name: example-lncs
+        run: docker run -v $(pwd)/test:/work/src -v /tmp/out:/work/out localhost:5000/name/app:latest work "pdflatex example-lncs.tex"
+      - run: mv /tmp/out/*.pdf /tmp/res
+      - uses: actions/upload-artifact@v2
+        with:
+          name: test-result
+          path: |
+            /tmp/res/*.pdf

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,8 @@
+FROM reitzig/texlive-base:2021.5
+
+RUN tlmgr update --self --repository https://mirror.mwt.me/ctan/systems/texlive/tlnet
+
+COPY test/Texlivefile /work/src
+
+RUN xargs tlmgr install --repository https://mirror.mwt.me/ctan/systems/texlive/tlnet < "/work/src/Texlivefile" && \
+    sha256sum "/work/src/Texlivefile" > "/work/tmp/Texlivefile.sha"

--- a/test/Texlivefile
+++ b/test/Texlivefile
@@ -1,0 +1,2 @@
+lipsum
+llncs

--- a/test/example-accepted.tex
+++ b/test/example-accepted.tex
@@ -1,12 +1,8 @@
 \documentclass[final, runningheads, USenglish, pdftex]{llncs}
 \usepackage{lipsum}
 
-%\usepackage[proceedings,crop]{llncsconf}
-\usepackage[llncs,crop]{llncsconf}
-%\conference{International Conference on \LaTeX-Hacks}
-\llncs{Anonymous et al.\ (eds).\ \emph{Proceedings of the International
-       Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
-\llncsdoi{10.1007/xxxx}
+\usepackage[accepted,crop]{llncsconf}
+\conference{International Conference on \LaTeX-Hacks}
 
 \title{A Simple Example of the \texttt{llncsconf} Package for \LaTeX}
 \author{\protect\href{http://www.brucker.ch/}{Achim D.~Brucker}}
@@ -27,5 +23,5 @@
 
 \section{Conclusion}
 \lipsum[10-12]
-% \label{LastPage}
+
 \end{document}

--- a/test/example-intended.tex
+++ b/test/example-intended.tex
@@ -1,12 +1,8 @@
 \documentclass[final, runningheads, USenglish, pdftex]{llncs}
 \usepackage{lipsum}
 
-%\usepackage[proceedings,crop]{llncsconf}
-\usepackage[llncs,crop]{llncsconf}
-%\conference{International Conference on \LaTeX-Hacks}
-\llncs{Anonymous et al.\ (eds).\ \emph{Proceedings of the International
-       Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
-\llncsdoi{10.1007/xxxx}
+\usepackage[intended,crop]{llncsconf}
+\conference{International Conference on \LaTeX-Hacks}
 
 \title{A Simple Example of the \texttt{llncsconf} Package for \LaTeX}
 \author{\protect\href{http://www.brucker.ch/}{Achim D.~Brucker}}
@@ -27,5 +23,5 @@
 
 \section{Conclusion}
 \lipsum[10-12]
-% \label{LastPage}
+
 \end{document}

--- a/test/example-lncs.tex
+++ b/test/example-lncs.tex
@@ -1,9 +1,7 @@
 \documentclass[final, runningheads, USenglish, pdftex]{llncs}
 \usepackage{lipsum}
 
-%\usepackage[proceedings,crop]{llncsconf}
 \usepackage[llncs,crop]{llncsconf}
-%\conference{International Conference on \LaTeX-Hacks}
 \llncs{Anonymous et al.\ (eds).\ \emph{Proceedings of the International
        Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
 \llncsdoi{10.1007/xxxx}
@@ -27,5 +25,4 @@
 
 \section{Conclusion}
 \lipsum[10-12]
-% \label{LastPage}
 \end{document}

--- a/test/example-proceedings.tex
+++ b/test/example-proceedings.tex
@@ -1,12 +1,9 @@
 \documentclass[final, runningheads, USenglish, pdftex]{llncs}
 \usepackage{lipsum}
 
-%\usepackage[proceedings,crop]{llncsconf}
-\usepackage[llncs,crop]{llncsconf}
-%\conference{International Conference on \LaTeX-Hacks}
+\usepackage[proceedings,crop]{llncsconf}
 \llncs{Anonymous et al.\ (eds).\ \emph{Proceedings of the International
        Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
-\llncsdoi{10.1007/xxxx}
 
 \title{A Simple Example of the \texttt{llncsconf} Package for \LaTeX}
 \author{\protect\href{http://www.brucker.ch/}{Achim D.~Brucker}}
@@ -27,5 +24,5 @@
 
 \section{Conclusion}
 \lipsum[10-12]
-% \label{LastPage}
+
 \end{document}

--- a/test/example-submitted.tex
+++ b/test/example-submitted.tex
@@ -1,12 +1,8 @@
 \documentclass[final, runningheads, USenglish, pdftex]{llncs}
 \usepackage{lipsum}
 
-%\usepackage[proceedings,crop]{llncsconf}
-\usepackage[llncs,crop]{llncsconf}
-%\conference{International Conference on \LaTeX-Hacks}
-\llncs{Anonymous et al.\ (eds).\ \emph{Proceedings of the International
-       Conference on \LaTeX-Hacks}, LNCS~-42. Some Publisher, 2016.}{0042}
-\llncsdoi{10.1007/xxxx}
+\usepackage[submitted,crop]{llncsconf}
+\conference{International Conference on \LaTeX-Hacks}
 
 \title{A Simple Example of the \texttt{llncsconf} Package for \LaTeX}
 \author{\protect\href{http://www.brucker.ch/}{Achim D.~Brucker}}
@@ -27,5 +23,5 @@
 
 \section{Conclusion}
 \lipsum[10-12]
-% \label{LastPage}
+
 \end{document}


### PR DESCRIPTION
This PR adds GitHub workflow based on reitzig's [texlive-docker](https://github.com/reitzig/texlive-docker) image.

I tried to make `example-*` files for each state a paper can have. The results are made available after build for inspection:

![grafik](https://user-images.githubusercontent.com/1366654/157564083-c67b03bb-2b17-467a-a724-4a49f5a7a473.png)

I removed ` \conference` for `proceedings` and `llncs`, because it was not necessary there (somehow a follow-up to #13) 

Note that the CI is enabled, because llncs finally made it to CTAN: https://ctan.org/pkg/llncs